### PR TITLE
Fix incompatibility between tqdm and pandas.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ catboost==0.13.1
 h5py==2.9.0
 tensorflow==1.13.1
 Keras==2.2.4
-tqdm==4.31.1
+tqdm==4.33.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=["numpy>=1.15.4", "pandas>=0.23.4", "scipy>=1.1.0", "scikit-learn>=0.20.0",
                         "xgboost==0.80", "lightgbm==2.2.3", "catboost==0.13.1",
-                        "h5py>=2.9.0", "tensorflow==1.13.1", "Keras==2.2.4", "tqdm==4.31.1"],
+                        "h5py>=2.9.0", "tensorflow==1.13.1", "Keras==2.2.4", "tqdm>=4.33"],
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6'


### PR DESCRIPTION
See https://github.com/tqdm/tqdm/issues/780 - tests couldn't be run. This issue came about because I installed it by running `python setup.py install` and not through 'requirements.txt'.