### PR TITLE
remove string of dicts from golden features json

### DIFF
--- a/supervised/preprocessing/goldenfeatures_transformer.py
+++ b/supervised/preprocessing/goldenfeatures_transformer.py
@@ -194,8 +194,8 @@ class GoldenFeaturesTransformer(object):
 
     def to_json(self):
         data_json = {
-            "new_features": json.dumps(self._new_features, indent=4),
-            "new_columns": json.dumps(self._new_columns, indent=4),
+            "new_features": self._new_features,
+            "new_columns": self._new_columns,
             "result_file": self._result_file,
             "ml_task": self._ml_task,
         }
@@ -204,8 +204,8 @@ class GoldenFeaturesTransformer(object):
         return data_json
 
     def from_json(self, data_json):
-        self._new_features = json.loads(data_json.get("new_features", []))
-        self._new_columns = json.loads(data_json.get("new_columns", []))
+        self._new_features = data_json.get("new_features", [])
+        self._new_columns = data_json.get("new_columns", [])
         self._result_file = data_json.get("result_file")
         self._ml_task = data_json.get("ml_task")
         self._error = data_json.get("error")


### PR DESCRIPTION
Fixes issue #227 

The golden_features.json now comprises only JSON dictionaries after removing the awkward string dumps of dictionaries. See example below.

```json
{
    "new_features": [
        {
            "feature1": "f1",
            "feature2": "f6",
            "operation": "ratio",
            "score": 0.6233122986
        },
        {
            "feature1": "f6",
            "feature2": "f3",
            "operation": "ratio",
            "score": 0.6662452285
        },
        {
            "feature1": "f8",
            "feature2": "f0",
            "operation": "ratio",
            "score": 0.749237433
        },
        {
            "feature1": "f7",
            "feature2": "f3",
            "operation": "ratio",
            "score": 0.7583642498
        },
        {
            "feature1": "f4",
            "feature2": "f7",
            "operation": "ratio",
            "score": 0.7990316411
        }
    ],
    "new_columns": [
        "f1_ratio_f6",
        "f6_ratio_f3",
        "f8_ratio_f0",
        "f7_ratio_f3",
        "f4_ratio_f7"
    ],
    "result_file": "sampleoutput/golden_features.json",
    "ml_task": "binary_classification"
}
```