### PR TITLE
fixed mae metric bug with lgbm (clean PR)

### DIFF
--- a/supervised/algorithms/lightgbm.py
+++ b/supervised/algorithms/lightgbm.py
@@ -59,7 +59,7 @@ def lightgbm_eval_metric(ml_task, automl_eval_metric):
         REGRESSION: {
             "rmse": "rmse",
             "mse": "l2",
-            "mae": "mae",
+            "mae": "l1",
             "mape": "mape",
             "r2": "custom",
             "spearman": "custom",


### PR DESCRIPTION
Hi @pplonski ,

I checked LightGBM docs and used the following code to check:
```
from lightgbm import LGBMRegressor
import numpy as np
X = np.random.randn(100, 10)
y = np.random.randn(100)
model = LGBMRegressor()
model.fit(X, y, eval_metric="mae")
```
The code excuted sucessfully, which means that LightGBM does support "mae" as metric. However, the problem exist in optuna mode for some reason. LightGBMObjective is returning "l1" instead of "mae"...
Anyways, by mapping "mae" to "l1" the error disappears.

Zacchaues