### PR TITLE
[Proposal] Add abstract methods to Base classes to enforce method overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ python setup.py install
 Installation for development
 ```
 git clone https://github.com/mljar/mljar-supervised.git
-virtualenv venv --python=python3.6
+virtualenv venv --python=python3.7
 source venv/bin/activate
 pip install -r requirements.txt
 pip install -r requirements_dev.txt

--- a/supervised/algorithms/algorithm.py
+++ b/supervised/algorithms/algorithm.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 import uuid
 import numpy as np
 from supervised.utils.importance import PermutationImportance
@@ -5,7 +6,7 @@ from supervised.utils.shap import PlotSHAP
 from supervised.utils.common import construct_learner_name
 
 
-class BaseAlgorithm:
+class BaseAlgorithm(ABC):
     """
     This is an abstract class.
     All algorithms inherit from BaseAlgorithm.
@@ -35,6 +36,7 @@ class BaseAlgorithm:
         if not self.is_fitted() and self.model_file_path is not None:
             self.load(self.model_file_path)
 
+    @abstractmethod
     def fit(
         self,
         X,
@@ -46,10 +48,11 @@ class BaseAlgorithm:
         log_to_file=None,
         max_time=None,
     ):
-        pass
+        ...
 
+    @abstractmethod
     def predict(self, X):
-        pass
+        ...
 
     # needed for feature importance
     def predict_proba(self, X):
@@ -58,17 +61,21 @@ class BaseAlgorithm:
             return y
         return np.column_stack((1 - y, y))
 
+    @abstractmethod
     def update(self, update_params):
-        pass
+        ...
 
+    @abstractmethod
     def copy(self):
-        pass
+        ...
 
+    @abstractmethod
     def save(self, model_file_path):
-        pass
+        ...
 
+    @abstractmethod
     def load(self, model_file_path):
-        pass
+        ...
 
     def get_fname(self):
         return f"{self.name}.{self.file_extension()}"
@@ -114,8 +121,9 @@ class BaseAlgorithm:
                 ml_task,
             )
 
+    @abstractmethod
     def get_metric_name(self):
-        return None
+        ....
 
     def get_params(self):
         params = {


### PR DESCRIPTION
Although, the current approach for defining the base class and corresponding methods also works, there is no enforcement (apart from code reviews and test driven development) for this. 

Abstract classes are useful as they enforce the users to override the abstractmethods. 

If maintainers and reviewers like this approach, I'd be inclined to have all the base classes structured in similar manner. 