### PR TITLE
Add option to choose which fold to use as a final predictor

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,6 @@
 pytest==5.3.5
 black==19.3b0
+click==8.0.2
+ipython
 pytest-cov
 coveralls

--- a/supervised/automl.py
+++ b/supervised/automl.py
@@ -71,6 +71,7 @@ class AutoML(BaseAutoML):
         n_jobs: int = -1,
         verbose: int = 1,
         random_state: int = 1234,
+        chosen_fold: Optional[int] = None,
     ):
         """
         Initialize `AutoML` object.
@@ -342,6 +343,7 @@ class AutoML(BaseAutoML):
         self.optuna_verbose = optuna_verbose
         self.n_jobs = n_jobs
         self.random_state = random_state
+        self.chosen_fold = chosen_fold
 
     def fit(
         self,

--- a/supervised/base_automl.py
+++ b/supervised/base_automl.py
@@ -930,6 +930,7 @@ class BaseAutoML(BaseEstimator, ABC):
         self._optuna_verbose = self._get_optuna_verbose()
         self._n_jobs = self._get_n_jobs()
         self._random_state = self._get_random_state()
+        self._chosen_fold = self._get_chosen_fold()
 
         self._adjust_validation = False
         self._apply_constraints()
@@ -1788,6 +1789,11 @@ class BaseAutoML(BaseEstimator, ABC):
         """Gets the current random_state"""
         self._validate_random_state()
         return deepcopy(self.random_state)
+    
+    def _get_chosen_fold(self):
+        """Gets the current chosen_fold"""
+        self._validate_chosen_fold()
+        return deepcopy(self.chosen_fold)
 
     def _validate_mode(self):
         """Validates mode parameter"""
@@ -2029,6 +2035,12 @@ class BaseAutoML(BaseEstimator, ABC):
     def _validate_random_state(self):
         """Validates random_state parameter"""
         check_positive_integer(self.random_state, "random_state")
+    
+    def _validate_chosen_fold(self):
+        """Validates chosen_fold parameter"""
+        if self.chosen_fold is None:
+            return
+        check_integer(self.chosen_fold, "chosen_fold")
 
     def to_json(self):
         if self._best_model is None:

--- a/supervised/ensemble.py
+++ b/supervised/ensemble.py
@@ -290,7 +290,7 @@ class Ensemble:
 
         self.train_time = time.time() - start_time
 
-    def predict(self, X, X_stacked=None):
+    def predict(self, X, X_stacked=None, chosen_fold=None):
         logger.debug(
             "Ensemble.predict with {} models".format(len(self.selected_models))
         )
@@ -303,9 +303,11 @@ class Ensemble:
             total_repeat += repeat
 
             if model._is_stacked:
-                y_predicted_from_model = model.predict(X_stacked)
+                y_predicted_from_model = model.predict(
+                    X_stacked, chosen_fold=chosen_fold
+                )
             else:
-                y_predicted_from_model = model.predict(X)
+                y_predicted_from_model = model.predict(X, chosen_fold=chosen_fold)
 
             prediction_cols = []
             if self._ml_task in [BINARY_CLASSIFICATION, MULTICLASS_CLASSIFICATION]:

--- a/tests/tests_automl/test_chosen_fold.py
+++ b/tests/tests_automl/test_chosen_fold.py
@@ -1,0 +1,52 @@
+import os
+import unittest
+import tempfile
+import json
+import numpy as np
+import pandas as pd
+import shutil
+
+from supervised import AutoML
+from supervised.exceptions import AutoMLException
+
+
+class AutoMLChosenFoldTest(unittest.TestCase):
+
+    automl_dir = "automl_testing"
+
+    def tearDown(self):
+        shutil.rmtree(self.automl_dir, ignore_errors=True)
+
+    def test_chosen_fold(self):
+
+        X = np.random.uniform(size=(60, 2))
+        y = np.random.randint(0, 2, size=(60,))
+
+        automl = AutoML(
+            results_path=self.automl_dir,
+            model_time_limit=10,
+            algorithms=["Xgboost"],
+            mode="Compete",
+            explain_level=0,
+            validation_strategy={
+                "validation_type": "kfold",
+                "k_folds": 5,
+                "shuffle": True,
+                "random_seed": 123,
+            },
+            start_random_models=1,
+            hill_climbing_steps=0,
+            top_models_to_improve=0,
+            kmeans_features=False,
+            golden_features=False,
+            features_selection=False,
+            boost_on_errors=False,
+            chosen_fold=-1,
+        )
+        automl.fit(X, y)
+        automl.predict_proba(X)
+        automl.predict(X)
+
+        self.assertFalse(
+            os.path.exists(os.path.join(self.automl_dir, "1_DecisionTree"))
+        )


### PR DESCRIPTION
Hi @pplonski ,

Thanks for this great package!
I use it pretty often so I wanted to add my contribution to it.

I needed to test the difference between taking the average of models fitted on each fold, and looking at the prediction of only the last fold.
This was especially interesting in my case as it was a time series split, and I wanted my final model to be the one trained on the most recent data.

I added a parameter in the AutoML class called `chosen_fold`, which I ultimately set at `-1` in my case to get the model of the last fold.

It's a bit linked to #475.

Feel free to tell me if I should continue working on this evolution!

P.S. : I think the changes in the requirements_dev.txt are needed because the last click versions are not compatible anymore with the pinned version of black. (see https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click)
Probably upgrading black could also be a good move.