### PR TITLE
FIX: errors in Ensemble while using custom_metric(use df.values to change dataframe to numpy array)

### DIFF
--- a/supervised/ensemble.py
+++ b/supervised/ensemble.py
@@ -360,7 +360,7 @@ class Ensemble:
                 ):
                     continue
                 y_ens = self._get_mean(oofs[model_name], best_sum, j + 1)
-                score = self.metric(y, y_ens, sample_weight)
+                score = self.metric(y.values, y_ens.values, sample_weight)
                 if self.metric.improvement(previous=min_score, current=score):
                     min_score = score
                     best_model = model_name


### PR DESCRIPTION
```
def custom_metric(y_true, y_predicted, sample_weight=None):
    v = 2 * abs(y_predicted - y_true) / ((abs(y_predicted) + abs(y_true)) + 1e-9)
    output = np.mean(v) * 100
    return output

automl = AutoML(mode=args.mode, algorithms=alg, eval_metric=custom_metric)
```
During Our project, we computed models using custom_eval_metric and met errors in Ensemble and Stacking Ensemble.
The problem was that in the ensemble step, the custom metric had an input type of DataFrame, not a numpy array.
So my pull request fixed this issue by just giving numpy array as input in the Ensemble step.

To other users who want to use this feature can code your function like the below
```
def custom_metric(y_true, y_predicted, sample_weight=None):
    if isinstance(y_true, pd.DataFrame):
        y_true = y_true.values
        y_predicted = y_predicted.values
        
    v = 2 * abs(y_predicted - y_true) / ((abs(y_predicted) + abs(y_true)) + 1e-9)
    output = np.mean(v) * 100
    return output
```