### PR TITLE
Fixed a small typo in model selection

### DIFF
--- a/supervised/automl.py
+++ b/supervised/automl.py
@@ -50,7 +50,7 @@ class AutoML(BaseAutoML):
                 Literal[
                     "Baseline",
                     "Linear",
-                    "Decicion Tree",
+                    "Decision Tree",
                     "Random Forest",
                     "Extra Trees",
                     "LightGBM",


### PR DESCRIPTION
There is an issue with selecting Decision Tree model as the name contains a typo.

Therefore, I corrected the line from "Decicion Tree" to "Decision Tree".