### PR TITLE
Logging enhancements

### DIFF
--- a/supervised/automl.py
+++ b/supervised/automl.py
@@ -21,9 +21,6 @@ from typing_extensions import (
 from supervised.base_automl import BaseAutoML
 from supervised.utils.config import LOG_LEVEL
 
-logging.basicConfig(
-    format="%(asctime)s %(name)s %(levelname)s %(message)s", level=logging.ERROR
-)
 logger = logging.getLogger(__name__)
 logger.setLevel(LOG_LEVEL)
 

--- a/supervised/base_automl.py
+++ b/supervised/base_automl.py
@@ -59,7 +59,6 @@ except Exception:
     REPORT_FONT = "Arial"
 
 logger = logging.getLogger(__name__)
-logger.setLevel(LOG_LEVEL)
 
 
 class BaseAutoML(BaseEstimator, ABC):
@@ -405,7 +404,7 @@ class BaseAutoML(BaseEstimator, ABC):
     def verbose_print(self, msg):
         if self._verbose > 0:
             # self._progress_bar.write(msg)
-            print(msg)
+            logging.info(msg)
 
     def ensemble_step(self, is_stacked=False):
         if self._train_ensemble and len(self._models) > 1:

--- a/supervised/exceptions.py
+++ b/supervised/exceptions.py
@@ -2,9 +2,6 @@ import logging
 
 from supervised.utils.config import LOG_LEVEL
 
-logging.basicConfig(
-    format="%(asctime)s %(name)s %(levelname)s %(message)s", level=logging.ERROR
-)
 logger = logging.getLogger(__name__)
 logger.setLevel(LOG_LEVEL)
 


### PR DESCRIPTION
The idea is not to set logging configuration in the code. As a library mljar should not set logging preferences, and let the application do it. In addition, verbose_print messages should go to logger so the application can get those messages if required.
Proposed changes:

* Remove calls to basicConfig on automl.py and exceptions.py 
* Change verbose_print to use logger.

