### PR TITLE
Fix future warning from pandas, improve test for categorical integers

### DIFF
--- a/supervised/preprocessing/preprocessing_categorical.py
+++ b/supervised/preprocessing/preprocessing_categorical.py
@@ -71,7 +71,14 @@ class PreprocessingCategorical(object):
                     # convert to integer
                     lbl = LabelEncoder()
                     lbl.from_json(lbl_params)
-                    X.loc[:, column] = lbl.transform(X.loc[:, column])
+                    transformed_values = lbl.transform(X.loc[:, column])
+                    # check for pandas FutureWarning: Setting an item
+                    # of incompatible dtype is deprecated and will raise
+                    # in a future error of pandas.
+                    if transformed_values.dtype != X.loc[:, column].dtype and \
+                        (X.loc[:, column].dtype == bool or X.loc[:, column].dtype == int):
+                        X = X.astype({column: transformed_values.dtype})
+                    X.loc[:, column] = transformed_values
 
             return X
 
@@ -86,7 +93,14 @@ class PreprocessingCategorical(object):
                 # convert to integer
                 lbl = LabelEncoder()
                 lbl.from_json(lbl_params)
-                X.loc[:, column] = lbl.inverse_transform(X.loc[:, column])
+                transformed_values = lbl.inverse_transform(X.loc[:, column])
+                # check for pandas FutureWarning: Setting an item
+                # of incompatible dtype is deprecated and will raise
+                # in a future error of pandas.
+                if transformed_values.dtype != X.loc[:, column].dtype and \
+                        (X.loc[:, column].dtype == bool or X.loc[:, column].dtype == int):
+                        X = X.astype({column: transformed_values.dtype})
+                X.loc[:, column] = transformed_values
 
         return X
 

--- a/tests/tests_preprocessing/test_categorical_integers.py
+++ b/tests/tests_preprocessing/test_categorical_integers.py
@@ -64,6 +64,68 @@ class CategoricalIntegersTest(unittest.TestCase):
         self.assertEqual(df["col4"][1], 1)
         self.assertEqual(df["col4"][2], 2)
 
+    def test_future_warning_pandas_transform(self):
+        import warnings
+        warnings.filterwarnings("error")
+
+        # training data
+        d = {
+            "col1": [False, True, True],
+            "col2": [False, False, True],
+            "col3": [True, False, True],
+        }
+        df = pd.DataFrame(data=d)
+        categorical = PreprocessingCategorical(
+            df.columns, PreprocessingCategorical.CONVERT_INTEGER
+        )
+        categorical.fit(df)
+
+        df = categorical.transform(df).astype(int)
+        df = categorical.inverse_transform(df)
+
+    def test_future_warning_pandas_inverse_transform(self):
+        import warnings
+
+        # training data
+        d = {
+            "col1": [False, True, True],
+            "col2": [False, False, True],
+            "col3": [True, False, True],
+        }
+        df = pd.DataFrame(data=d)
+        categorical = PreprocessingCategorical(
+            df.columns, PreprocessingCategorical.CONVERT_INTEGER
+        )
+        categorical.fit(df)
+
+        df = categorical.transform(df).astype(int)
+        warnings.filterwarnings("error")
+        df = categorical.inverse_transform(df)
+
+    def test_fit_transform_inverse_transform_integers(self):
+        # training data
+        d = {
+            "col1": [1, 2, 3],
+            "col2": ["a", "a", "c"],
+            "col3": [1, 1, 3],
+            "col4": ["a", "b", "c"],
+        }
+        df = pd.DataFrame(data=d)
+        categorical = PreprocessingCategorical(
+            df.columns, PreprocessingCategorical.CONVERT_INTEGER
+        )
+        categorical.fit(df)
+        df_transform = categorical.transform(df).astype(int)
+        df_inverse = categorical.inverse_transform(df_transform)
+        for col in ["col1", "col2", "col3", "col4"]:
+            self.assertTrue(col in df_inverse.columns)
+        self.assertEqual(d["col2"][0], df_inverse["col2"][0])
+        self.assertEqual(d["col2"][1], df_inverse["col2"][1])
+        self.assertEqual(d["col2"][2], df_inverse["col2"][2])
+        self.assertEqual(d["col4"][0], df_inverse["col4"][0])
+        self.assertEqual(d["col4"][1], df_inverse["col4"][1])
+        self.assertEqual(d["col4"][2], df_inverse["col4"][2])
+
     def test_fit_transform_integers_with_new_values(self):
         # training data
         d_train = {

--- a/tests/tests_preprocessing/test_categorical_integers.py
+++ b/tests/tests_preprocessing/test_categorical_integers.py
@@ -81,7 +81,6 @@ class CategoricalIntegersTest(unittest.TestCase):
         categorical.fit(df)
 
         df = categorical.transform(df).astype(int)
-        df = categorical.inverse_transform(df)
 
     def test_future_warning_pandas_inverse_transform(self):
         import warnings


### PR DESCRIPTION
Dear all,

I had a lot of future warnings (`FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas`) from pandas in the functions `transform` and `inverse_transform` of the class `PreprocessingCategorical`. I added a test for this and fixed it in the code.

In addtion when looking over the tests I did not saw a test for checking for the `inverse_transform` I added now also a test for this one.

If you have any issues with the fix let me know.