### PR TITLE
Force use of Linear algorithm

### DIFF
--- a/supervised/base_automl.py
+++ b/supervised/base_automl.py
@@ -820,7 +820,7 @@ class BaseAutoML(BaseEstimator, ABC):
             self.verbose_print(
                 "Neural Network algorithm was disabled because it doesn't support n_jobs parameter."
             )
-        if "Linear" in self._algorithms and not (
+        if "Linear" in self._algorithms and len(self._algorithms) > 1 and and not (
             self.n_rows_in_ < 10000 and self.n_features_in_ < 1000
         ):
             self._algorithms.remove("Linear")


### PR DESCRIPTION
mljar-supervised removes the Linear algorithm for dataset larger than 10,000 rows. I had such dataset, and needed to see how Linear behaved. If I set Linear as the only algorithm, I obtained this error:

supervised.exceptions.AutoMLException: No models produced. Please check your data or submit a Github issue at https://github.com/mljar/mljar-supervised/issues/new.

This is not a mljar-supervised bug. I wonder this pull request is useful for others too.

