### PR TITLE
add catching of expected errors in tests (fixes #752, #753, #761, #762) 

### DIFF
--- a/supervised/preprocessing/exclude_missing_target.py
+++ b/supervised/preprocessing/exclude_missing_target.py
@@ -23,7 +23,8 @@ class ExcludeRowsMissingTarget(object):
         logger.debug("Exclude rows with missing target values")
         if warn:
             warnings.warn(
-                "There are samples with missing target values in the data which will be excluded for further analysis"
+                "There are samples with missing target values in the data which will be excluded for further analysis",
+                UserWarning
             )
         y = y.drop(y.index[y_missing])
         y.reset_index(drop=True, inplace=True)

--- a/supervised/validation/validator_kfold.py
+++ b/supervised/validation/validator_kfold.py
@@ -25,7 +25,9 @@ class KFoldValidator(BaseValidator):
         self.repeats = self.params.get("repeats", 1)
 
         if not self.shuffle and self.repeats > 1:
-            warnings.warn("Disable repeats in validation because shuffle is disabled")
+            warnings.warn(
+                "Disable repeats in validation because shuffle is disabled", UserWarning
+            )
             self.repeats = 1
 
         self.skf = []

--- a/supervised/validation/validator_split.py
+++ b/supervised/validation/validator_split.py
@@ -24,7 +24,9 @@ class SplitValidator(BaseValidator):
         self.repeats = self.params.get("repeats", 1)
 
         if not self.shuffle and self.repeats > 1:
-            warnings.warn("Disable repeats in validation because shuffle is disabled")
+            warnings.warn(
+                "Disable repeats in validation because shuffle is disabled", UserWarning
+            )
             self.repeats = 1
 
         self._results_path = self.params.get("results_path")

--- a/tests/tests_automl/test_targets.py
+++ b/tests/tests_automl/test_targets.py
@@ -1,5 +1,6 @@
 import shutil
 import unittest
+import pytest
 
 import numpy as np
 import pandas as pd
@@ -100,7 +101,16 @@ class AutoMLTargetsTest(unittest.TestCase):
             explain_level=0,
             start_random_models=1,
         )
-        automl.fit(X, y)
+
+        with pytest.warns(
+            expected_warning=UserWarning,
+            match="There are samples with missing target values in the data which will be excluded for further analysis",
+        ) as record:
+            automl.fit(X, y)
+
+        # check that only one warning was raised
+        self.assertEqual(len(record), 1)
+
         p = automl.predict(X)
         pred = automl.predict(X)
 
@@ -256,7 +266,16 @@ class AutoMLTargetsTest(unittest.TestCase):
             explain_level=0,
             start_random_models=1,
         )
-        automl.fit(X, y)
+
+        with pytest.warns(
+            expected_warning=UserWarning,
+            match="There are samples with missing target values in the data which will be excluded for further analysis",
+        ) as record:
+            automl.fit(X, y)
+
+        # check that only one warning was raised
+        self.assertEqual(len(record), 1)
+
         pred = automl.predict(X)
 
         u = np.unique(pred)

--- a/tests/tests_validation/test_validator_kfold.py
+++ b/tests/tests_validation/test_validator_kfold.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+import pytest
 
 import numpy as np
 import pandas as pd
@@ -194,7 +195,15 @@ class KFoldValidatorTest(unittest.TestCase):
                 "y_path": y_path,
                 "random_seed": 1,
             }
-            vl = KFoldValidator(params)
+
+            with pytest.warns(
+                expected_warning=UserWarning,
+                match="Disable repeats in validation because shuffle is disabled",
+            ) as record:
+                vl = KFoldValidator(params)
+
+            # check that only one warning was raised
+            self.assertEqual(len(record), 1)
 
             self.assertEqual(params["k_folds"], vl.get_n_splits())
             self.assertEqual(1, vl.get_repeats())

--- a/tests/tests_validation/test_validator_split.py
+++ b/tests/tests_validation/test_validator_split.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+import pytest
 
 import numpy as np
 import pandas as pd
@@ -211,7 +212,15 @@ class SplitValidatorTest(unittest.TestCase):
                 "y_path": y_path,
                 "repeats": 3,
             }
-            vl = SplitValidator(params)
+
+            with pytest.warns(
+                expected_warning=UserWarning,
+                match="Disable repeats in validation because shuffle is disabled",
+            ) as record:
+                vl = SplitValidator(params)
+
+            # check that only one warning was raised
+            self.assertEqual(len(record), 1)
 
             self.assertEqual(1, vl.get_n_splits())
             self.assertEqual(1, vl.get_repeats())


### PR DESCRIPTION
if a autoML function throws a intended warning expect it

added
```python
with pytest.warns(
    expected_warning=UserWarning,
    match="There are samples with missing target values in the data which will be excluded for further analysis",
) as record:
    automl.fit(X, y)

# check that only one warning was raised
self.assertEqual(len(record), 1)
```
in appropriate tests