### PR TITLE
add catch for autoML warning and a check for pandas future warning (fixes #754)

### DIFF
--- a/supervised/preprocessing/scale.py
+++ b/supervised/preprocessing/scale.py
@@ -45,6 +45,8 @@ class Scale(object):
             if self.scale_method == self.SCALE_NORMAL:
                 X.loc[:, self.columns] = self.scale.inverse_transform(X[self.columns])
             elif self.scale_method == self.SCALE_LOG_AND_NORMAL:
+                X[self.columns] = X[self.columns].astype("float64")
+
                 X[self.columns] = self.scale.inverse_transform(X[self.columns])
                 X[self.columns] = np.exp(X[self.columns])
 

--- a/tests/tests_automl/test_targets.py
+++ b/tests/tests_automl/test_targets.py
@@ -317,7 +317,14 @@ class AutoMLTargetsTest(unittest.TestCase):
             explain_level=0,
             start_random_models=1,
         )
-        automl.fit(X, y)
+
+        with pytest.warns(
+            match="There are samples with missing target values in the data which will be excluded for further analysis"
+        ) as record:
+            automl.fit(X, y)
+
+        self.assertEqual(len(record), 1)
+
         pred = automl.predict(X)
 
         self.assertIsInstance(pred, np.ndarray)


### PR DESCRIPTION
added a check for when autoML warning is thrown by `autoML.fit()`
```python
with pytest.warns(
    match="There are samples with missing target values in the data which will be excluded for further analysis"
) as record:
    automl.fit(X, y)

self.assertEqual(len(record), 1)
```

and a fix for setting a value with incompatible dtype (it threw future warning)
```python
X[self.columns] = X[self.columns].astype("float64")
``` 