### PR TITLE
change X.iloc[:, 1] to X[column_name] so there is no warning from pandas (fixes #750)

### DIFF
--- a/supervised/algorithms/catboost.py
+++ b/supervised/algorithms/catboost.py
@@ -198,9 +198,10 @@ class CatBoostAlgorithm(BaseAlgorithm):
             for i in range(X.shape[1]):
                 if PreprocessingUtils.is_categorical(X.iloc[:, i]):
                     self.cat_features += [i]
-                    X.iloc[:, i] = X.iloc[:, i].astype(str)
+                    col_name = X.columns[i]
+                    X[col_name] = X[col_name].astype(str)
                     if X_validation is not None:
-                        X_validation.iloc[:, i] = X_validation.iloc[:, i].astype(str)
+                        X_validation[col_name] = X_validation[col_name].astype(str)
 
         eval_set = None
         if X_validation is not None and y_validation is not None:


### PR DESCRIPTION
changed 
  ```python
X.iloc[:, i] = X.iloc[:, i].astype(str)

if X_validation is not None:
    X_validation.iloc[:, i] = X_validation.iloc[:, i].astype(str)
```
to
```python
col_name = X.columns[i]
X[col_name] = X[col_name].astype(str)

if X_validation is not None:
    X_validation[col_name] = X_validation[col_name].astype(str)
```
this prevents Future warning from pandas of setting incompatible dtype
