### PR TITLE
Add connector.autoload for automatic data loading

### DIFF
--- a/connector/autoload.py
+++ b/connector/autoload.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import os
+
+def load_data(path, **kwargs):
+    ext = os.path.splitext(path)[1].lower()
+    if ext in ['.csv', '.tsv']:
+        return pd.read_csv(path, **kwargs)
+    elif ext in ['.xls', '.xlsx', '.ods']:
+        return pd.read_excel(path, **kwargs)
+    elif ext == '.json':
+        return pd.read_json(path, **kwargs)
+    else:
+        raise ValueError(f"Unsupported file type: {ext}")


### PR DESCRIPTION
This PR introduces a connector module that automatically infers and loads tabular data from CSV, Excel, or JSON files, reducing boilerplate for MLJAR users.