### PR TITLE
fix: handle empty value_counts in get_most_frequent to prevent IndexError

### DIFF
--- a/supervised/preprocessing/preprocessing_utils.py
+++ b/supervised/preprocessing/preprocessing_utils.py
@@ -111,7 +111,10 @@ class PreprocessingUtils(object):
     @staticmethod
     def get_most_frequent(x):
         a = x.value_counts()
-        first = sorted(dict(a).items(), key=lambda x: -x[1])[0]
+        sorted_items = sorted(dict(a).items(), key=lambda x: -x[1])
+        if not sorted_items:
+            return None
+        first = sorted_items[0]
         return first[0]
 
     @staticmethod


### PR DESCRIPTION
Fixes #770

## Problem
`get_most_frequent()` in `preprocessing_utils.py` crashes with `IndexError: list index out of range` when `value_counts()` returns an empty Series. This happens during preprocessing when a column has no valid values.

## Root Cause
```python
# Buggy - crashes if sorted list is empty
first = sorted(dict(a).items(), key=lambda x: -x[1])[0]
```

## Fix
```python
# Fixed - gracefully handles empty case
sorted_items = sorted(dict(a).items(), key=lambda x: -x[1])
if not sorted_items:
    return None
first = sorted_items[0]
return first[0]
```

## Impact
- No breaking changes
- Prevents crash during model training when columns have no valid values