### PR TITLE
Add get_leaderboard() public method to AutoML class

### DIFF
--- a/supervised/automl.py
+++ b/supervised/automl.py
@@ -28,7 +28,6 @@ logger.setLevel(LOG_LEVEL)
 
 
 class AutoML(BaseAutoML):
-
     """
     Automated Machine Learning for supervised tasks (binary classification, multiclass classification, regression).
     """
@@ -437,12 +436,12 @@ class AutoML(BaseAutoML):
         finally:
             matplotlib.use(original_backend)
             try:
-                if 'inline' in original_backend:
+                if "inline" in original_backend:
                     import matplotlib_inline
+
                     matplotlib_inline.backend_inline._enable_matplotlib_integration()
             except:
                 pass
-
 
     def predict(self, X: Union[List, numpy.ndarray, pandas.DataFrame]) -> numpy.ndarray:
         """
@@ -531,6 +530,26 @@ class AutoML(BaseAutoML):
             - For regression tasks: returns the R^2 (coefficient of determination) on the given test data and labels.
         """
         return self._score(X, y, sample_weight)
+
+    def get_leaderboard(
+        self,
+        filter_random_feature: bool = False,
+        original_metric_values: bool = False,
+    ) -> pandas.DataFrame:
+        """Returns a leaderboard DataFrame with a summary of all trained models.
+
+        Arguments:
+            filter_random_feature (bool):
+                If True, models trained with a random feature are filtered out.
+
+            original_metric_values (bool):
+                If True, returns original metric values (not negated for minimized metrics).
+
+        Returns:
+            pandas.DataFrame: DataFrame with columns: name, model_type, metric_type,
+                metric_value, train_time.
+        """
+        return super().get_leaderboard(filter_random_feature, original_metric_values)
 
     def report(self, width=900, height=1200):
         return self._report(width, height)

--- a/tests/tests_automl/test_automl.py
+++ b/tests/tests_automl/test_automl.py
@@ -165,6 +165,24 @@ class AutoMLTest(unittest.TestCase):
         score = model.fit(iris.data, iris.target).score(iris.data, iris.target)
         self.assertGreater(score, 0.5)
 
+    def test_get_leaderboard(self):
+        """Tests that get_leaderboard() returns a valid DataFrame after fitting"""
+        model = AutoML(
+            explain_level=0,
+            verbose=0,
+            random_state=1,
+            results_path=self.automl_dir,
+        )
+        model.fit(iris.data, iris.target)
+
+        ldb = model.get_leaderboard()
+
+        self.assertIsInstance(ldb, pd.DataFrame)
+        for col in ["name", "model_type", "metric_type", "metric_value", "train_time"]:
+            self.assertIn(col, ldb.columns)
+        # multiple models trained, leaderboard should have more than one row
+        self.assertGreater(len(ldb), 1)
+
     def test_housing_dataset(self):
         """Tests AutoML in the housing dataset (Regression)"""
         model = AutoML(


### PR DESCRIPTION
Closes #806

## What this PR does
Exposes `get_leaderboard()` as a public method on the `AutoML` class.

The method already existed in `BaseAutoML` but was not accessible 
from the public API. Users call:

`automl.get_leaderboard()`

and get back a pandas DataFrame with all trained models and their metrics.

## Changes
- Added `get_leaderboard()` to `supervised/automl.py` with full docstring
- Added `test_get_leaderboard()` to `tests/tests_automl/test_automl.py`

## Testing
All existing tests pass. New test verifies the method returns a valid 
DataFrame with expected columns and multiple rows.