### PR TITLE
fix: normalize path separators for cross-platform model loading

### DIFF
--- a/supervised/model_framework.py
+++ b/supervised/model_framework.py
@@ -721,6 +721,7 @@ class ModelFramework:
         for learner_desc, learner_subpath in zip(
             json_desc.get("learners"), json_desc.get("saved")
         ):
+            learner_subpath = os.path.normpath(learner_subpath)
             learner_path = os.path.join(results_path, learner_subpath)
             l = AlgorithmFactory.load(learner_desc, learner_path, lazy_load)
             mf.learners += [l]


### PR DESCRIPTION
## Summary

When a model is trained on Windows and loaded on Linux, `learner_subpath` paths contain backslash separators. On Linux, `os.path.join` does not normalize backslashes, producing malformed paths like:

> `experiments_dir/model_1/100_LightGBM\\learner_fold_0.lightgbm`

This causes model loading to fail.

## Changes

Added `os.path.normpath()` call to normalize path separators in `learner_subpath` before joining with `results_path` in the `load` method. This handles both directions:
- **Windows → Linux**: backslashes converted to forward slashes
- **Linux → Windows**: forward slashes converted to backslashes

## Test Plan

- [ ] Train a model on Windows, copy to Linux, verify it loads
- [ ] Train a model on Linux, copy to Windows, verify it loads

Closes #541