### PR TITLE
Fix TfidfVectorizer compatibility with older sklearn versions

### DIFF
--- a/supervised/preprocessing/text_transformer.py
+++ b/supervised/preprocessing/text_transformer.py
@@ -4,6 +4,17 @@ import pandas as pd
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 
+def _get_feature_names(vectorizer):
+    """Return feature names from a TfidfVectorizer, compatible with both old and new sklearn.
+
+    Older sklearn (pre-0.24) uses ``get_feature_names()``, while newer sklearn
+    (>= 0.24) uses ``get_feature_names_out()``.
+    """
+    if hasattr(vectorizer, "get_feature_names_out"):
+        return vectorizer.get_feature_names_out()
+    return vectorizer.get_feature_names()
+
+
 class TextTransformer(object):
     def __init__(self):
         self._new_columns = []
@@ -22,7 +33,7 @@ class TextTransformer(object):
 
         x = X[column][~pd.isnull(X[column])]
         self._vectorizer.fit(x)
-        for f in list(self._vectorizer.get_feature_names_out()):
+        for f in list(_get_feature_names(self._vectorizer)):
             new_col = self._old_column + "_" + f
             self._new_columns += [new_col]
 


### PR DESCRIPTION
## Description

Fixes #486

The  method was introduced in scikit-learn 0.24. Older sklearn versions use  instead.

This PR adds a compatibility wrapper  that checks which method is available via , falling back gracefully.

## Changes
- Added  helper function in `supervised/preprocessing/text_transformer.py`
- Changed `fit()` to use the wrapper instead of directly calling `get_feature_names_out()`

## Testing
- sklearn >= 0.24: uses `get_feature_names_out()` (no change in behavior)
- sklearn < 0.24: falls back to `get_feature_names()`