### PR TITLE
Fix cross-platform path normalization for model loading (#541)

### DIFF
--- a/supervised/model_framework.py
+++ b/supervised/model_framework.py
@@ -721,6 +721,9 @@ class ModelFramework:
         for learner_desc, learner_subpath in zip(
             json_desc.get("learners"), json_desc.get("saved")
         ):
+            # Normalize path separators for cross-platform compatibility
+            # (models trained on Windows may have backslashes in paths)
+            learner_subpath = learner_subpath.replace("\\", "/")
             learner_path = os.path.join(results_path, learner_subpath)
             l = AlgorithmFactory.load(learner_desc, learner_path, lazy_load)
             mf.learners += [l]


### PR DESCRIPTION
## Description
When a model is trained on Windows, `os.path.join` stores paths with backslashes (e.g., `model_1/100_LightGBM\\learner_fold_0.lightgbm`). Loading the model on Linux fails because `os.path.join` doesn't handle the mixed separators correctly.

## Fix
Normalize backslashes to forward slashes in `learner_subpath` before joining with `results_path`, enabling models trained on Windows to be loaded on Linux (and vice versa).

## Related Issue
Closes #541