### PR TITLE
Fix IndexError in get_most_frequent when column is all null

### DIFF
--- a/supervised/preprocessing/preprocessing_utils.py
+++ b/supervised/preprocessing/preprocessing_utils.py
@@ -111,6 +111,8 @@ class PreprocessingUtils(object):
     @staticmethod
     def get_most_frequent(x):
         a = x.value_counts()
+        if a.empty:
+            return None
         first = sorted(dict(a).items(), key=lambda x: -x[1])[0]
         return first[0]
 


### PR DESCRIPTION
## Description

Fixes #770

When `PreprocessingMissingValues` encounters a column containing exclusively null values, `x.value_counts()` returns an empty Series. The subsequent `sorted(...)[0]` raises an `IndexError: list index out of range`.

## Fix

Added an early return of `None` when `value_counts()` is empty, allowing the caller to proceed with a safe fallback fill value.

## Testing

- `value_counts()` on a non-null column → returns most frequent value (existing behavior preserved)
- `value_counts()` on an all-null column → returns `None` (previously crashed)

## Changes

`supervised/preprocessing/preprocessing_utils.py` — 2 lines added