### PR TITLE
Fix #790: expose min_samples_per_class, warn on upsampling, fix metrics on original rows

### DIFF
--- a/supervised/automl.py
+++ b/supervised/automl.py
@@ -83,6 +83,7 @@ class AutoML(BaseAutoML):
         n_jobs: int = -1,
         verbose: int = 1,
         random_state: int = 1234,
+        min_samples_per_class: int = 20,
     ):
         """
         Initialize `AutoML` object.
@@ -307,6 +308,12 @@ class AutoML(BaseAutoML):
 
             random_state (int): Controls the randomness of the `AutoML`
 
+            min_samples_per_class (int): Minimum number of samples per class required for training.
+                If a class has fewer samples, additional rows are created by random oversampling
+                with replacement before model training. Metrics, confusion matrices, and ensembles
+                are computed on original rows only. Set to ``0`` to disable oversampling.
+                The effective minimum is also at least ``k_folds`` when using k-fold validation.
+
 
         Examples:
 
@@ -409,6 +416,7 @@ class AutoML(BaseAutoML):
         self.underprivileged_groups = underprivileged_groups
         self.n_jobs = n_jobs
         self.random_state = random_state
+        self.min_samples_per_class = min_samples_per_class
 
     def fit(
         self,

--- a/supervised/base_automl.py
+++ b/supervised/base_automl.py
@@ -117,6 +117,7 @@ class BaseAutoML(BaseEstimator, ABC):
         self._underprivileged_groups = []
         self._optuna_verbose = True
         self._n_jobs = -1
+        self._min_samples_per_class = None
         self._id = str(uuid.uuid4())
 
     def _get_tuner_params(
@@ -186,6 +187,7 @@ class BaseAutoML(BaseEstimator, ABC):
             )
             self._n_jobs = params.get("n_jobs", self._n_jobs)
             self._random_state = params.get("random_state", self._random_state)
+            self._min_samples_per_class = params.get("min_samples_per_class", 20)
             stacked_models = params.get("stacked")
 
             best_model_name = params.get("best_model")
@@ -426,6 +428,7 @@ class BaseAutoML(BaseEstimator, ABC):
                 fairness_threshold=self._fairness_threshold,
                 privileged_groups=self._privileged_groups,
                 underprivileged_groups=self._underprivileged_groups,
+                original_rows=self._validation_strategy.get("original_rows"),
             )
             (
                 oofs,
@@ -581,10 +584,26 @@ class BaseAutoML(BaseEstimator, ABC):
         # save information about original data
         self._save_data_info(X, y, sample_weight, sensitive_features)
 
-        # handle drastic imbalance
-        # assure at least 20 samples of each class
-        # for binary and multiclass classification
-        self._handle_drastic_imbalance(X, y, sample_weight, sensitive_features)
+        # upsample classes with fewer than min_samples_per_class (for model training)
+        upsampling_info = self._handle_drastic_imbalance(
+            X, y, sample_weight, sensitive_features
+        )
+        if upsampling_info is not None:
+            self._data_info["upsampling"] = upsampling_info
+            data_info_path = os.path.join(self._results_path, "data_info.json")
+            with open(data_info_path, "w") as fout:
+                fout.write(json.dumps(self._data_info, indent=4, cls=MLJSONEncoder))
+            self._validation_strategy["original_rows"] = upsampling_info[
+                "original_rows"
+            ]
+            self.verbose_print(
+                "Upsampling applied: classes with fewer than "
+                f"{upsampling_info['min_samples_per_class']} samples were duplicated "
+                f"with replacement ({upsampling_info['original_rows']} -> "
+                f"{upsampling_info['training_rows']} rows). "
+                "Metrics and ensembles use original rows only. "
+                "Set min_samples_per_class=0 to disable."
+            )
 
         # prepare path for saving files
         self._X_path = os.path.join(self._results_path, "X.data")
@@ -635,16 +654,23 @@ class BaseAutoML(BaseEstimator, ABC):
         self, X, y, sample_weight=None, sensitive_features=None
     ):
         if self._ml_task == REGRESSION:
-            return
+            return None
+        if self._min_samples_per_class <= 0:
+            return None
+
         classes, cnts = np.unique(y, return_counts=True)
-        min_samples_per_class = 20
+        min_samples_per_class = self._min_samples_per_class
         if self._validation_strategy is not None:
             min_samples_per_class = max(
                 min_samples_per_class, self._validation_strategy.get("k_folds", 0)
             )
+
+        original_rows = X.shape[0]
+        appended_per_class = {}
         for i in range(len(classes)):
             if cnts[i] < min_samples_per_class:
                 append_samples = min_samples_per_class - cnts[i]
+                appended_per_class[str(classes[i])] = int(append_samples)
                 new_X = (
                     X[y == classes[i]]
                     .sample(n=append_samples, replace=True, random_state=1)
@@ -673,6 +699,17 @@ class BaseAutoML(BaseEstimator, ABC):
                         sensitive_features.loc[
                             sensitive_features.shape[0]
                         ] = new_sensitive_features.loc[j]
+
+        if not appended_per_class:
+            return None
+
+        return {
+            "min_samples_per_class": int(min_samples_per_class),
+            "original_rows": int(original_rows),
+            "training_rows": int(X.shape[0]),
+            "appended_rows": int(X.shape[0] - original_rows),
+            "appended_per_class": appended_per_class,
+        }
 
     def _save_data_info(self, X, y, sample_weight=None, sensitive_features=None):
         target_is_numeric = pd.api.types.is_numeric_dtype(y)
@@ -1029,6 +1066,7 @@ class BaseAutoML(BaseEstimator, ABC):
         self._optuna_verbose = self._get_optuna_verbose()
         self._n_jobs = self._get_n_jobs()
         self._random_state = self._get_random_state()
+        self._min_samples_per_class = self._get_min_samples_per_class()
 
         if sensitive_features is not None:
             self._fairness_metric = self._get_fairness_metric()
@@ -1374,6 +1412,7 @@ class BaseAutoML(BaseEstimator, ABC):
                 "max_single_prediction_time": self._max_single_prediction_time,
                 "n_jobs": self._n_jobs,
                 "random_state": self._random_state,
+                "min_samples_per_class": self._min_samples_per_class,
                 "saved": self._model_subpaths,
                 "fit_level": self._fit_level,
             }
@@ -1970,6 +2009,11 @@ class BaseAutoML(BaseEstimator, ABC):
         self._validate_random_state()
         return deepcopy(self.random_state)
 
+    def _get_min_samples_per_class(self):
+        """Gets the current min_samples_per_class"""
+        self._validate_min_samples_per_class()
+        return deepcopy(self.min_samples_per_class)
+
     def _validate_mode(self):
         """Validates mode parameter"""
         valid_modes = ["Explain", "Perform", "Compete", "Optuna"]
@@ -2210,6 +2254,10 @@ class BaseAutoML(BaseEstimator, ABC):
     def _validate_random_state(self):
         """Validates random_state parameter"""
         check_positive_integer(self.random_state, "random_state")
+
+    def _validate_min_samples_per_class(self):
+        """Validates min_samples_per_class parameter"""
+        check_positive_integer(self.min_samples_per_class, "min_samples_per_class")
 
     def _validate_fairness_metric(self):
         """Validates fariness_metric parameter"""

--- a/supervised/ensemble.py
+++ b/supervised/ensemble.py
@@ -19,6 +19,11 @@ from supervised.utils.additional_metrics import AdditionalMetrics
 from supervised.utils.config import LOG_LEVEL
 from supervised.utils.jsonencoder import MLJSONEncoder
 from supervised.utils.metric import Metric
+from supervised.utils.oof_utils import (
+    filter_oof_to_original_rows,
+    filter_oofs_dict,
+    filter_target_to_original_rows,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(LOG_LEVEL)
@@ -42,6 +47,7 @@ class Ensemble:
         fairness_threshold=None,
         privileged_groups=None,
         underprivileged_groups=None,
+        original_rows=None,
     ):
         self.library_version = "0.1"
         self.uid = str(uuid.uuid4())
@@ -75,6 +81,7 @@ class Ensemble:
         self._underprivileged_groups = underprivileged_groups
         self._is_fair = None
         self.sensitive_features = None
+        self._original_rows = original_rows
 
     def get_train_time(self):
         return self.train_time
@@ -208,7 +215,9 @@ class Ensemble:
             logger.debug("Get additional metrics for Ensemble")
             # 'target' - the target after processing used for model training
             # 'prediction' - out of folds predictions of the model
-            oof_predictions = self.get_out_of_folds()
+            oof_predictions = filter_oof_to_original_rows(
+                self.get_out_of_folds(), self._original_rows
+            )
             prediction_cols = [c for c in oof_predictions.columns if "prediction" in c]
             target_cols = [c for c in oof_predictions.columns if "target" in c]
 
@@ -333,6 +342,16 @@ class Ensemble:
 
     def fit(self, oofs, y, sample_weight=None, sensitive_features=None):
         logger.debug("Ensemble.fit")
+        oofs = filter_oofs_dict(oofs, self._original_rows)
+        y = filter_target_to_original_rows(y, self._original_rows)
+        if sample_weight is not None:
+            sample_weight = filter_target_to_original_rows(
+                sample_weight, self._original_rows
+            )
+        if sensitive_features is not None:
+            sensitive_features = filter_target_to_original_rows(
+                sensitive_features, self._original_rows
+            )
         self.sensitive_features = sensitive_features
         start_time = time.time()
         selected_algs_cnt = 0  # number of selected algorithms

--- a/supervised/model_framework.py
+++ b/supervised/model_framework.py
@@ -23,6 +23,7 @@ from supervised.utils.additional_metrics import AdditionalMetrics
 from supervised.utils.config import LOG_LEVEL
 from supervised.utils.jsonencoder import MLJSONEncoder
 from supervised.utils.metric import Metric
+from supervised.utils.oof_utils import filter_oof_to_original_rows
 from supervised.validation.validation_step import ValidationStep
 
 logger = logging.getLogger(__name__)
@@ -386,7 +387,33 @@ class ModelFramework:
 
         return early_stopping.best_y_oof
 
+    def _get_oof_for_metrics(self):
+        oof = self.get_out_of_folds()
+        original_rows = self.validation_params.get("original_rows")
+        return filter_oof_to_original_rows(oof, original_rows)
+
+    def _compute_loss_from_oof(self, oof):
+        metric = self.get_metric()
+        target_cols = [c for c in oof.columns if "target" in c]
+        prediction_cols = [c for c in oof.columns if "prediction" in c]
+        sample_weight = None
+        if "sample_weight" in oof.columns:
+            sample_weight = oof["sample_weight"]
+        if "prediction" in oof.columns:
+            return metric(
+                oof[target_cols], oof["prediction"], sample_weight=sample_weight
+            )
+        return metric(
+            oof[target_cols], oof[prediction_cols], sample_weight=sample_weight
+        )
+
     def get_final_loss(self):
+        original_rows = self.validation_params.get("original_rows")
+        if original_rows is not None:
+            oof = self._get_oof_for_metrics()
+            if oof is not None and not oof.empty:
+                return self._compute_loss_from_oof(oof)
+
         if self.final_loss is not None:
             return self.final_loss
         early_stopping = self.callbacks.get("early_stopping")
@@ -463,7 +490,7 @@ class ModelFramework:
             logger.debug("Compute additional metrics")
             # 'target' - the target after processing used for model training
             # 'prediction' - out of folds predictions of the model
-            oof_predictions = self.get_out_of_folds()
+            oof_predictions = self._get_oof_for_metrics()
             prediction_cols = [c for c in oof_predictions.columns if "prediction" in c]
             target_cols = [c for c in oof_predictions.columns if "target" in c]
 

--- a/supervised/utils/oof_utils.py
+++ b/supervised/utils/oof_utils.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+
+def filter_oof_to_original_rows(oof_df, original_rows):
+    """Keep only out-of-fold predictions for original (non-upsampled) rows."""
+    if original_rows is None or oof_df is None or oof_df.empty:
+        return oof_df
+    if oof_df.shape[0] <= original_rows:
+        return oof_df
+    return oof_df[oof_df.index < original_rows].copy(deep=True)
+
+
+def filter_oofs_dict(oofs, original_rows):
+    if original_rows is None:
+        return oofs
+    return {
+        name: filter_oof_to_original_rows(oof, original_rows)
+        for name, oof in oofs.items()
+    }
+
+
+def filter_target_to_original_rows(target, original_rows):
+    if original_rows is None or target is None:
+        return target
+    if isinstance(target, pd.DataFrame):
+        if target.shape[0] <= original_rows:
+            return target
+        return target[target.index < original_rows].copy(deep=True)
+    if isinstance(target, pd.Series):
+        if target.shape[0] <= original_rows:
+            return target
+        return target[target.index < original_rows].copy(deep=True)
+    return target

--- a/tests/tests_automl/test_handle_imbalance.py
+++ b/tests/tests_automl/test_handle_imbalance.py
@@ -1,6 +1,9 @@
 import shutil
 import unittest
 
+import json
+import os
+
 import numpy as np
 import pandas as pd
 
@@ -22,12 +25,13 @@ class AutoMLHandleImbalanceTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.automl_dir, ignore_errors=True)
 
-    def test_handle_drastic_imbalance(self):
-        a = AutoML(
+    def _make_automl(self, min_samples_per_class=20):
+        return AutoML(
             results_path=self.automl_dir,
             total_time_limit=10,
             algorithms=["Random Forest"],
             train_ensemble=False,
+            min_samples_per_class=min_samples_per_class,
             validation_strategy={
                 "validation_type": "kfold",
                 "k_folds": 10,
@@ -36,6 +40,9 @@ class AutoMLHandleImbalanceTest(unittest.TestCase):
             },
             start_random_models=1,
         )
+
+    def test_handle_drastic_imbalance(self):
+        a = self._make_automl()
 
         rows = 100
         X = pd.DataFrame(
@@ -51,26 +58,24 @@ class AutoMLHandleImbalanceTest(unittest.TestCase):
         y[10:12] = 2
         y = pd.Series(np.array(y), name="target")
         a._ml_task = MULTICLASS_CLASSIFICATION
-        a._handle_drastic_imbalance(X, y)
+        a._min_samples_per_class = 20
+        a._validation_strategy = {
+            "validation_type": "kfold",
+            "k_folds": 10,
+            "shuffle": True,
+            "stratify": True,
+        }
+        info = a._handle_drastic_imbalance(X, y)
 
         self.assertEqual(X.shape[0], 130)
         self.assertEqual(X.shape[1], 3)
         self.assertEqual(y.shape[0], 130)
+        self.assertEqual(info["original_rows"], 100)
+        self.assertEqual(info["training_rows"], 130)
+        self.assertEqual(info["appended_rows"], 30)
 
     def test_handle_drastic_imbalance_sample_weight(self):
-        a = AutoML(
-            results_path=self.automl_dir,
-            total_time_limit=10,
-            algorithms=["Random Forest"],
-            train_ensemble=False,
-            validation_strategy={
-                "validation_type": "kfold",
-                "k_folds": 10,
-                "shuffle": True,
-                "stratify": True,
-            },
-            start_random_models=1,
-        )
+        a = self._make_automl()
 
         rows = 100
         X = pd.DataFrame(
@@ -88,6 +93,13 @@ class AutoMLHandleImbalanceTest(unittest.TestCase):
 
         y = pd.Series(np.array(y), name="target")
         a._ml_task = MULTICLASS_CLASSIFICATION
+        a._min_samples_per_class = 20
+        a._validation_strategy = {
+            "validation_type": "kfold",
+            "k_folds": 10,
+            "shuffle": True,
+            "stratify": True,
+        }
         a._handle_drastic_imbalance(X, y, sample_weight)
 
         self.assertEqual(X.shape[0], 138)
@@ -132,3 +144,75 @@ class AutoMLHandleImbalanceTest(unittest.TestCase):
         self.assertEqual(X.shape[0], rows)
         self.assertEqual(y.shape[0], rows)
         self.assertEqual(sample_weight.shape[0], rows)
+
+    def test_min_samples_per_class_disabled(self):
+        rows = 59
+        X = pd.DataFrame({"f1": np.random.rand(rows), "f2": np.random.rand(rows)})
+        y = pd.Series(np.concatenate([np.zeros(15), np.ones(44)]))
+
+        a = AutoML(
+            results_path=self.automl_dir,
+            total_time_limit=10,
+            algorithms=["Baseline"],
+            train_ensemble=False,
+            min_samples_per_class=0,
+            validation_strategy={
+                "validation_type": "kfold",
+                "k_folds": 5,
+                "shuffle": True,
+                "stratify": True,
+            },
+            explain_level=0,
+        )
+        a.fit(X, y)
+
+        with open(os.path.join(self.automl_dir, "data_info.json")) as fin:
+            data_info = json.load(fin)
+
+        self.assertEqual(data_info["rows"], rows)
+        self.assertNotIn("upsampling", data_info)
+
+        oof = a._models[0].get_out_of_folds()
+        self.assertEqual(oof.shape[0], rows)
+
+    def test_min_samples_per_class_records_upsampling(self):
+        rows = 59
+        X = pd.DataFrame({"f1": np.random.rand(rows), "f2": np.random.rand(rows)})
+        y = pd.Series(np.concatenate([np.zeros(15), np.ones(44)]))
+
+        a = AutoML(
+            results_path=self.automl_dir,
+            total_time_limit=10,
+            algorithms=["Baseline"],
+            train_ensemble=False,
+            min_samples_per_class=20,
+            validation_strategy={
+                "validation_type": "kfold",
+                "k_folds": 5,
+                "shuffle": True,
+                "stratify": True,
+            },
+            explain_level=0,
+        )
+        a.fit(X, y)
+
+        with open(os.path.join(self.automl_dir, "data_info.json")) as fin:
+            data_info = json.load(fin)
+
+        self.assertEqual(data_info["rows"], rows)
+        self.assertIn("upsampling", data_info)
+        self.assertEqual(data_info["upsampling"]["original_rows"], rows)
+        self.assertEqual(data_info["upsampling"]["training_rows"], 64)
+        self.assertEqual(data_info["upsampling"]["appended_rows"], 5)
+
+        oof_all = pd.read_csv(
+            os.path.join(
+                self.automl_dir,
+                a._models[0].get_name(),
+                "predictions_out_of_folds.csv",
+            )
+        )
+        self.assertEqual(oof_all.shape[0], 64)
+
+        metrics_oof = a._models[0]._get_oof_for_metrics()
+        self.assertEqual(metrics_oof.shape[0], rows)


### PR DESCRIPTION
Fixes #790

## Problem

Users reported that cross-validation produced fold indices and OOF
predictions beyond the original dataset size (e.g. 59 rows in
`data_info.json`, but indices 59–63 in `fold_*_validation_indices.npy`
and 64 rows in `predictions_out_of_folds.csv`).

The cause was not a bug in StratifiedKFold. Before validation,
`_handle_drastic_imbalance()` in `base_automl.py` silently oversampled
minority classes to reach a hardcoded minimum of 20 samples per class
(also bumped to at least `k_folds` when using k-fold CV). Cross-validation
then ran on this enlarged dataset, so extra indices and OOF rows were
expected but undocumented.

This led to:
- Confusion about whether CV was broken
- Confusion matrices and ensemble evaluation on the wrong row count
- No way to disable or discover the behavior

## Solution

### 1. New `AutoML` parameter: `min_samples_per_class` (default `20`)

- Same default as before, so existing behavior is preserved unless changed.
- Set to `0` to disable pre-validation oversampling entirely.

```python
automl = AutoML(min_samples_per_class=0)  # no synthetic rows
```
### 2. Transparency when upsampling occurs
- Console warning at fit time with before/after row counts.
- data_info.json gains an upsampling section:
```json
{
  "rows": 59,
  "upsampling": {
    "min_samples_per_class": 20,
    "original_rows": 59,
    "training_rows": 64,
    "appended_rows": 5,
    "appended_per_class": {"0.0": 5}
  }
}
```
rows continues to reflect the original input size.

### 3. Correct evaluation on original rows
Metrics and model comparison now exclude appended rows:

- Confusion matrices and additional metrics (ModelFramework)
- Leaderboard final_loss / get_final_loss()
- Ensemble greedy selection (Ensemble.fit())

Training and fold generation still use the upsampled dataset when enabled, which some algorithms need for minimum class counts / stratified folds.

### 4. Implementation notes
- original_rows is stored in validation_strategy and persisted in model framework.json via existing params serialization.
- New helper module supervised/utils/oof_utils.py filters OOF predictions to indices < original_rows (safe because _build_dataframe resets index to 0..n-1 and appended rows are added at the end).

### What is unchanged / known limitations
- predictions_out_of_folds.csv still contains all training rows (including synthetic ones) for debugging; use data_info.json["upsampling"] or _get_oof_for_metrics() to work with original rows only.
- Stacking (get_stacked_data) and boost_on_errors still read unfiltered OOF; follow-up if needed.
- Internal method name _handle_drastic_imbalance kept for now to minimize diff scope.

code attribution : claude code