### PR TITLE
fix: resolve TypeError during leaderboard sort on AutoML reload (fixes #681)

### DIFF
--- a/supervised/ensemble.py
+++ b/supervised/ensemble.py
@@ -571,7 +571,13 @@ class Ensemble:
                 {"model": models_map[m["model"]], "repeat": m["repeat"]}
             ]
 
-        ensemble.best_loss = json_desc.get("final_loss", ensemble.best_loss)
+        best_loss = json_desc.get("final_loss", ensemble.best_loss)
+        if best_loss is not None:
+            try:
+                best_loss = float(best_loss)
+            except ValueError:
+                pass
+        ensemble.best_loss = best_loss
         ensemble.train_time = json_desc.get("train_time", ensemble.train_time)
         ensemble._is_stacked = json_desc.get("is_stacked", ensemble._is_stacked)
         predictions_fname = json_desc.get("predictions_fname")

--- a/supervised/model_framework.py
+++ b/supervised/model_framework.py
@@ -625,7 +625,7 @@ class ModelFramework:
                 "is_stacked": self._is_stacked,
                 "joblib_version": joblib.__version__,
             }
-            desc["final_loss"] = str(desc["final_loss"])
+            desc["final_loss"] = desc["final_loss"]
             if self._threshold is not None:
                 desc["threshold"] = self._threshold
             if self._single_prediction_time is not None:
@@ -707,7 +707,13 @@ class ModelFramework:
         mf._name = json_desc.get("name", mf._name)
         mf._threshold = json_desc.get("threshold")
         mf.train_time = json_desc.get("train_time", mf.train_time)
-        mf.final_loss = json_desc.get("final_loss", mf.final_loss)
+        final_loss = json_desc.get("final_loss", mf.final_loss)
+        if final_loss is not None:
+            try:
+                final_loss = float(final_loss)
+            except ValueError:
+                pass
+        mf.final_loss = final_loss
         mf.metric_name = json_desc.get("metric_name", mf.metric_name)
         mf._is_stacked = json_desc.get("is_stacked", mf._is_stacked)
         mf._single_prediction_time = json_desc.get(


### PR DESCRIPTION
## Summary
Fixes #681 — AutoML reload crashes with `TypeError: '<' not supported 
between instances of 'float' and 'str'` during model stacking or 
leaderboard sorting.

## Root Cause
1. `ModelFramework.save()` serialized `final_loss` to `framework.json` 
   as a string via `str(desc["final_loss"])`.
2. `ModelFramework.load()` read it back as a raw string (e.g. `"0.1234"`).
3. When new models were trained alongside reloaded ones, the leaderboard 
   mixed `float` (new models) and `str` (reloaded models) in `metric_value`.
4. `ldb.sort_values(by="metric_value")` crashed because Python 3 does not 
   support `<` comparisons between `float` and `str`.

## Changes
- **`supervised/model_framework.py`**
  - Removed `str()` cast from `final_loss` in `ModelFramework.save()` 
    so it is written as a numeric float
  - Added `float()` conversion in `ModelFramework.load()` with a 
    try-except for backward compatibility with older saved directories
- **`supervised/ensemble.py`**
  - Added `float()` conversion in `Ensemble.load()` when reading 
    `best_loss` from `ensemble.json` for extra robustness

## Testing
Verified by reloading a saved AutoML directory and continuing training — 
leaderboard sorts correctly with no TypeError.

Closes #681