### PR TITLE
fix: handle null-only text column in TextTransformer.transform (#801)

### DIFF
--- a/supervised/preprocessing/text_transformer.py
+++ b/supervised/preprocessing/text_transformer.py
@@ -33,12 +33,13 @@ class TextTransformer(object):
             )
             ii = ~pd.isnull(X[self._old_column])
             x = X[self._old_column][ii]
-            vect = self._vectorizer.transform(x)
 
             for f in self._new_columns:
                 X[f] = 0.0
 
-            X.loc[ii, self._new_columns] = vect.toarray()
+            if x.shape[0] > 0:
+                vect = self._vectorizer.transform(x)
+                X.loc[ii, self._new_columns] = vect.toarray()
             X.drop(self._old_column, axis=1, inplace=True)
         return X
 


### PR DESCRIPTION
Fixes #801
In Perform mode, _base_predict is called with a single sample (X.iloc[:1]) to measure prediction time. If that sample's text column is null, filtering out nulls produces an empty array — causing TfidfVectorizer.transform() to crash with "Found array with 0 sample(s)". Explain mode is unaffected because _max_single_prediction_time is None there, so _base_predict is never called.
Fix (supervised/preprocessing/text_transformer.py): initialize output columns to 0.0 first, then only call the vectorizer when there are non-null rows. Null-only inputs get zero-filled columns, which is the correct default.