### PR TITLE
Fix deprecated friedman_mse criterion

### DIFF
--- a/docs/docs/features/algorithms.md
+++ b/docs/docs/features/algorithms.md
@@ -38,13 +38,16 @@ The `Decision Tree` is using scikit-learn [`DecisionTreeRegressor`](https://scik
     The allowed values of hyperparameters:
     ```python
     dt_params = {
-        "criterion": ["mse", "friedman_mse"], 
+        "criterion": ["squared_error"],
         "max_depth": [2, 3, 4]
     }
     ```
     The default set of hyperparameters:
     ```python
-    classification_default_params = {"criterion": "mse", "max_depth": 3}
+    regression_default_params = {
+        "criterion": "squared_error",
+        "max_depth": 3
+    }
     ```
 
 For `Decision Tree` a visualization can be created with `dtreeviz` package (not to have `explain_level > 0`).

--- a/supervised/algorithms/decision_tree.py
+++ b/supervised/algorithms/decision_tree.py
@@ -282,7 +282,6 @@ AlgorithmsRegistry.add(
 dt_regression_params = {
     "criterion": [
         "squared_error",
-        "friedman_mse",
     ],  # remove "mae" because it slows down a lot https://github.com/scikit-learn/scikit-learn/issues/9626
     "max_depth": [2, 3, 4],
 }


### PR DESCRIPTION
## Description

Fixes #838.

The `friedman_mse` criterion for `DecisionTreeRegressor` is deprecated
in scikit-learn and will be removed in a future release.

### Changes
- Removed `friedman_mse` from Decision Tree regression hyperparameters.
- Updated documentation to use `squared_error`.
- Updated the documented default criterion to `squared_error`.

### Testing
- `python -m unittest tests.tests_algorithms.test_decision_tree -v`
- All 3 tests passed.
- `git diff --check` passes.
- Verified no remaining `friedman_mse` references with `git grep`.